### PR TITLE
Console redirecting sys.stderr and sys.stdout

### DIFF
--- a/runestone/activecode/js/activecode_brython.js
+++ b/runestone/activecode/js/activecode_brython.js
@@ -23,13 +23,78 @@ export default class BrythonActiveCode extends ActiveCode {
         $(this.outDiv).show({ duration: 700, queue: false });
         prog = `
         <html>
-            <head>
-                <script type='text/javascript' src='https://cdn.jsdelivr.net/npm/brython@3.9.0/brython.min.js'></script>
-            </head>
-            <body onload='brython()'>
-                <script type='text/python'>${prog}
-                </script>
-            </body>
+        <head>
+            <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/brython@3.9.4/brython.min.js"></script>
+            <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/brython@3.9.4/brython_stdlib.min.js"></script>
+            <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.0.1/styles/default.min.css">
+            <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.0.1/highlight.min.js"></script>
+            <style>
+                pre {
+                    position: absolute; font-size: 13px; width: 94%; padding: 9.5px; line-height: 1.42857143; border: 1px ; border-radius: 4px;
+                }
+                code{
+                    border: 1px solid #ccc; border-radius: 4px;
+                }
+            </style>
+        </head>
+        <body onload='brython()' >
+            <pre id="consolePre">
+                <code id="consoleCode"></code>
+            </pre>
+            <script type='text/python'>
+import sys
+from browser import document, html
+from browser.html import *
+
+logger = document['consoleCode']
+preElem = document['consolePre']
+class NewOut:
+    def write(self, data):
+        logger.innerHTML += str(data)
+
+sys.stderr = sys.stdout = NewOut()
+            </script>
+            <script type="text/python3">
+from browser import document, html
+import sys
+
+try:
+    exec("""${prog}
+""")
+    preElem = document['consolePre']
+    preElem.style.visibility = "visible"
+    preElem.style.bottom = "5px"
+    document['consoleCode'].classList.add("plaintext")
+
+except Exception as msg:
+    
+    # formatting sys.exc_info()
+    trace = str(sys.exc_info())
+    try:
+        trace_list = trace.split(",")
+        err_type = trace_list[1].split('(')[0][1:]
+        line = trace_list[3][1:] if err_type != 'IndentationError' else "'unknown'"
+        result =  f"'{err_type}': {msg} on line {line}."
+    except Exception as e:
+        result = trace.replace(',',"")
+    print(result)
+    
+    # Styling the pre element for error
+    logger = document['consoleCode']
+    preElem = document['consolePre']
+    error_header = document.createElement("h3")
+    error_header.innerHTML = "Error"
+    error_header.style.font = "24px 'Arial'"
+    preElem.prepend(error_header)
+    preElem.style.visibility = "visible"
+    preElem.style.top = "5px"
+    preElem.style.backgroundColor = "#f2dede"
+    preElem.style.border = "1px solid #ebccd1"
+    logger.classList.add("python")
+
+document <= html.SCRIPT("hljs.highlightAll();")
+            </script>
+        </body>
         </html>
         `;
         this.output.srcdoc = prog;

--- a/runestone/activecode/js/activecode_brython.js
+++ b/runestone/activecode/js/activecode_brython.js
@@ -60,7 +60,7 @@ import traceback
 
 def my_exec(code):
     try:
-        exec(code)
+        exec(code, locals())
         preElem = document['consolePre']
         preElem.style.visibility = "visible"
         preElem.style.bottom = "5px"
@@ -68,20 +68,25 @@ def my_exec(code):
     except SyntaxError as err:
         error_class = err.__class__.__name__
         detail = err.args[0]
-        line_number = err.lineno
-    except Exception as err:
+        line_number = f"at line {err.lineno}"
+    except BaseException as err:
         error_class = err.__class__.__name__
         detail = err.args[0]
         cl, exc, tb = sys.exc_info()
-        line_number = traceback.extract_tb(tb)[-1][1]
+        # When errors don't specify a line
+        try:
+            line_number = f"at line {traceback.extract_tb(tb)[-1][1]}"
+        except:
+            line_number = ""
     else:
         return
     
     # This is only done if an Exception was catched
-    result = f"'{error_class}': {detail} at line {line_number}."
+    result = f"'{error_class}': {detail} {line_number}"
     print(result)
     logger = document['consoleCode']
     preElem = document['consolePre']
+    # Styling the pre element for error
     error_header = document.createElement("h3")
     error_header.innerHTML = "Error"
     error_header.style.font = "24px 'Arial'"

--- a/runestone/activecode/test/_sources/index.rst
+++ b/runestone/activecode/test/_sources/index.rst
@@ -2832,7 +2832,7 @@ Trying Brython as Python 3 interpreter
    :language: python3
    :python3_interpreter: brython 
 
-   print("You can see this print on the browser console")
+   print("You can see this print inside the iframe console")
    from browser import document, alert, html
 
    def hello(ev):


### PR DESCRIPTION
This PR resolves #12 and partially closes https://github.com/angelasofiaremolinagutierrez/PyZombis/issues/11
This is a different approach to this PR #11 where console.log method is overriden. 
> by default, print() will output to the web browser console and so are the error messages. sys.stderr and sys.stdout can be assigned to an object with a write() method, and this allows for the redirection of output to go to a window or text area, for example.

This can be found in the Brython[ documentation page](https://brython.info/static_doc/en/syntax.html) 
And that is exactly what I did:

1. First I redirect the sys.stderr and sys.stdout to a `<code>` tag I have on the html.
2. Then inside a try except I run the code received in the textarea with `exec()` if there is no problem the result is shown on screen. And if there is an Exception I format the traceback received by `sys.exc_info()` and print in on screen.
3. The `<code>` tag is highlighted with highlight.js when there is an error.

Here is a gif of how it's looking:

![console-highlight-exec](https://user-images.githubusercontent.com/10239480/123563485-83136380-d77a-11eb-8a02-3ac911e36e44.gif)

