### PR TITLE
Style corrections for console to display correctly

### DIFF
--- a/runestone/activecode/js/activecode_brython.js
+++ b/runestone/activecode/js/activecode_brython.js
@@ -31,6 +31,7 @@ export default class BrythonActiveCode extends ActiveCode {
             <style>
                 pre {
                     position: absolute; font-size: 13px; width: 94%; padding: 9.5px; line-height: 1.42857143; border: 1px ; border-radius: 4px;
+                    overflow: auto; height: 200px; clear: both; position: sticky; top: 0; resize: both; background: white;
                 }
                 code{
                     border: 1px solid #ccc; border-radius: 4px;
@@ -63,8 +64,11 @@ def my_exec(code):
         exec(code, locals())
         preElem = document['consolePre']
         preElem.style.visibility = "visible"
-        preElem.style.bottom = "5px"
         document['consoleCode'].classList.add("plaintext")
+        out_header = document.createElement("h3")
+        out_header.innerHTML = "Output"
+        out_header.style.font = "24px 'Arial'"
+        preElem.prepend(out_header)
     except SyntaxError as err:
         error_class = err.__class__.__name__
         detail = err.args[0]


### PR DESCRIPTION
This PR resolves #15 
Now the console:
-  Has css style (sticky) that allows the console to show above everything else in page.
- Has a scroll bar
- Is resizable

**Note the dist folder must be updated after merging this one**

![console-resizable](https://user-images.githubusercontent.com/10239480/124684242-4d662d00-de94-11eb-8dcc-7b33f8d1fb08.gif)
